### PR TITLE
- feat(examples): added folders for storing examples of code;

### DIFF
--- a/src/python/src/examples/database/models/cities.py
+++ b/src/python/src/examples/database/models/cities.py
@@ -1,0 +1,25 @@
+from database.models.base import Base
+from database.models.mixins import (
+    MysqlPrimaryKeyMixin,
+    MysqlTimestampsMixin,
+    MysqlStatusMixin,
+    MysqlErrorMixin,
+    JSONSerializable,
+)
+from sqlalchemy.dialects.mysql import (
+    BIGINT,
+    VARCHAR
+)
+from sqlalchemy import Column, text
+from sqlalchemy.sql.schema import Column, UniqueConstraint
+
+
+class Cities(
+    Base, MysqlPrimaryKeyMixin, MysqlStatusMixin, MysqlTimestampsMixin, MysqlErrorMixin, JSONSerializable
+):
+    __tablename__ = "cities"
+    name = Column("name", VARCHAR(255), nullable=False, unique=False, index=True)
+    state_id = Column("state_id", BIGINT(unsigned=True), nullable=False, unique=False, index=True)
+
+    UniqueConstraint("name", "state_id", name="uq_cities_first_name_state_id")
+

--- a/src/python/src/examples/database/models/countries.py
+++ b/src/python/src/examples/database/models/countries.py
@@ -1,0 +1,24 @@
+from database.models.base import Base
+from database.models.mixins import (
+    MysqlPrimaryKeyMixin,
+    MysqlTimestampsMixin,
+    MysqlStatusMixin,
+    MysqlErrorMixin,
+    JSONSerializable,
+)
+from sqlalchemy.dialects.mysql import (
+    VARCHAR
+)
+from sqlalchemy import Column
+from sqlalchemy.sql.schema import Column
+
+
+class Countries(
+    Base, MysqlPrimaryKeyMixin, MysqlStatusMixin, MysqlTimestampsMixin, MysqlErrorMixin, JSONSerializable
+):
+    __tablename__ = "countries"
+
+    name = Column("name", VARCHAR(255), nullable=False,  unique=False, index=True)
+    iso = Column("iso", VARCHAR(2), nullable=False, unique=True, index=False)
+    continent_code = Column("continent_code", VARCHAR(2), nullable=False, unique=True, index=False)
+    currency_code = Column("currency_code", VARCHAR(3), nullable=False, unique=True, index=False)

--- a/src/python/src/examples/database/models/first_names.py
+++ b/src/python/src/examples/database/models/first_names.py
@@ -1,0 +1,31 @@
+from database.models.base import Base
+from sqlalchemy import text
+from database.models.mixins import (
+    MysqlPrimaryKeyMixin,
+    MysqlTimestampsMixin,
+    MysqlStatusMixin,
+    MysqlErrorMixin,
+    JSONSerializable,
+)
+from sqlalchemy.dialects.mysql import (
+    VARCHAR,
+    FLOAT,
+    INTEGER,
+    BOOLEAN
+)
+from sqlalchemy import FLOAT, Column
+from sqlalchemy.sql.schema import Column
+from sqlalchemy.sql.schema import Column, UniqueConstraint
+
+
+class FirstNames(
+    Base, MysqlPrimaryKeyMixin, MysqlStatusMixin, MysqlTimestampsMixin, MysqlErrorMixin, JSONSerializable
+):
+    __tablename__ = "first_names"
+
+    first_name = Column("first_name", VARCHAR(255), nullable=False,  unique=False, index=True)
+    frequency = Column("frequency", FLOAT(), nullable=True, unique=False, index=False)
+    count = Column("count", INTEGER(unsigned=True), nullable=True, unique=False, index=False)
+    gender = Column("gender", BOOLEAN(), nullable=True, unique=False, index=True, server_default=text("0"))
+
+    UniqueConstraint("first_name", "gender", name="uq_first_names_first_name_gender")

--- a/src/python/src/examples/database/models/last_names.py
+++ b/src/python/src/examples/database/models/last_names.py
@@ -1,0 +1,25 @@
+from database.models.base import Base
+from sqlalchemy import text
+from database.models.mixins import (
+    MysqlPrimaryKeyMixin,
+    MysqlTimestampsMixin,
+    MysqlStatusMixin,
+    MysqlErrorMixin,
+    JSONSerializable,
+)
+from sqlalchemy.dialects.mysql import (
+    INTEGER,
+    VARCHAR,
+    FLOAT
+)
+from sqlalchemy import Column, text
+from sqlalchemy.sql.schema import Column, UniqueConstraint
+
+
+class LastNames(
+    Base, MysqlPrimaryKeyMixin, MysqlStatusMixin, MysqlTimestampsMixin, MysqlErrorMixin, JSONSerializable
+):
+    __tablename__ = "last_names"
+    last_name = Column("last_name", VARCHAR(255), nullable=False, unique=False, index=True)
+    frequency = Column("frequency", FLOAT(), nullable=True, unique=False, index=False)
+    count = Column("count", INTEGER(unsigned=True), nullable=True, unique=False, index=False)

--- a/src/python/src/examples/database/models/states.py
+++ b/src/python/src/examples/database/models/states.py
@@ -1,0 +1,24 @@
+from database.models.base import Base
+from database.models.mixins import (
+    MysqlPrimaryKeyMixin,
+    MysqlTimestampsMixin,
+    MysqlStatusMixin,
+    MysqlErrorMixin,
+    JSONSerializable,
+)
+from sqlalchemy.dialects.mysql import (
+    BIGINT,
+    VARCHAR
+)
+from sqlalchemy import Column, text
+from sqlalchemy.sql.schema import Column, UniqueConstraint
+
+
+class States(
+    Base, MysqlPrimaryKeyMixin, MysqlStatusMixin, MysqlTimestampsMixin, MysqlErrorMixin, JSONSerializable
+):
+    __tablename__ = "states"
+    name = Column("name", VARCHAR(255), nullable=False, unique=False, index=True)
+    country_id = Column("country_id", BIGINT(unsigned=True), nullable=False, unique=False, index=True)
+
+    UniqueConstraint("name", "country_id", name="uq_states_first_name_country_id")

--- a/src/python/src/examples/database/versions/create_cities_table.py
+++ b/src/python/src/examples/database/versions/create_cities_table.py
@@ -1,0 +1,31 @@
+from alembic import op
+from sqlalchemy import Column, text
+from sqlalchemy.dialects.mysql import BIGINT, TIMESTAMP, MEDIUMINT, VARCHAR, TEXT, FLOAT, INTEGER, BOOLEAN
+
+
+revision = None
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "cities",
+        Column("id", BIGINT(unsigned=True), primary_key=True, autoincrement=True),
+        Column("name", VARCHAR(length=255), index=True, unique=False, nullable=False),
+        Column("state_id", BIGINT(unsigned=True), index=True, unique=False, nullable=False),
+
+        Column("status", MEDIUMINT(unsigned=True), index=True, unique=False, nullable=False, default=0,
+               server_default=text("0")),
+        Column("exception", TEXT(), index=False, unique=False, nullable=True, default=None),
+        Column("created_at", TIMESTAMP, nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+        Column("updated_at", TIMESTAMP, nullable=False, index=True, unique=False,
+               server_default=text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")),
+        mysql_collate="utf8mb4_unicode_ci"
+    )
+    op.create_unique_constraint('uq_cities_first_name_state_id', 'cities', ['name', 'state_id'])
+
+
+def downgrade():
+    op.drop_table("cities")

--- a/src/python/src/examples/database/versions/create_countries_table.py
+++ b/src/python/src/examples/database/versions/create_countries_table.py
@@ -1,0 +1,32 @@
+from alembic import op
+from sqlalchemy import Column, text
+from sqlalchemy.dialects.mysql import BIGINT, TIMESTAMP, MEDIUMINT, VARCHAR, TEXT, FLOAT, INTEGER, BOOLEAN
+
+
+revision = None
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "countries",
+        Column("id", BIGINT(unsigned=True), primary_key=True, autoincrement=True),
+        Column("name", VARCHAR(length=255), index=True, unique=False, nullable=False),
+        Column("iso", VARCHAR(length=2), index=False, unique=True, nullable=False),
+        Column("continent_code", VARCHAR(length=2), index=False, unique=True, nullable=False),
+        Column("currency_code", VARCHAR(length=3), index=False, unique=True, nullable=False),
+
+        Column("status", MEDIUMINT(unsigned=True), index=True, unique=False, nullable=False, default=0,
+               server_default=text("0")),
+        Column("exception", TEXT(), index=False, unique=False, nullable=True, default=None),
+        Column("created_at", TIMESTAMP, nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+        Column("updated_at", TIMESTAMP, nullable=False, index=True, unique=False,
+               server_default=text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")),
+        mysql_collate="utf8mb4_unicode_ci"
+    )
+
+
+def downgrade():
+    op.drop_table("countries")

--- a/src/python/src/examples/database/versions/create_first_names_table.py
+++ b/src/python/src/examples/database/versions/create_first_names_table.py
@@ -1,0 +1,33 @@
+from alembic import op
+from sqlalchemy import Column, text
+from sqlalchemy.dialects.mysql import BIGINT, TIMESTAMP, MEDIUMINT, VARCHAR, TEXT, FLOAT, INTEGER, BOOLEAN
+
+
+revision = None
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "first_names",
+        Column("id", BIGINT(unsigned=True), primary_key=True, autoincrement=True),
+        Column("first_name", VARCHAR(length=255), index=True, unique=False, nullable=False),
+        Column("frequency", FLOAT(), index=False, unique=False, nullable=True, default=None),
+        Column("count", INTEGER(unsigned=True), index=False, unique=False, nullable=True, default=None),
+        Column("gender", BOOLEAN(), index=True, unique=False, nullable=True, default=None,
+               server_default=text("0")),
+        Column("status", MEDIUMINT(unsigned=True), index=True, unique=False, nullable=False, default=0,
+               server_default=text("0")),
+        Column("exception", TEXT(), index=False, unique=False, nullable=True, default=None),
+        Column("created_at", TIMESTAMP, nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+        Column("updated_at", TIMESTAMP, nullable=False, index=True, unique=False,
+               server_default=text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")),
+        mysql_collate="utf8mb4_unicode_ci"
+    )
+    op.create_unique_constraint('uq_first_names_first_name_gender', 'first_names', ['first_name', 'gender'])
+
+
+def downgrade():
+    op.drop_table("first_names")

--- a/src/python/src/examples/database/versions/create_last_names_table.py
+++ b/src/python/src/examples/database/versions/create_last_names_table.py
@@ -1,0 +1,37 @@
+
+from alembic import op
+from sqlalchemy import Column, text
+from sqlalchemy.dialects.mysql import BIGINT, TIMESTAMP, MEDIUMINT, VARCHAR, TEXT, FLOAT, INTEGER
+
+
+revision = None
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "last_names",
+        Column("id", BIGINT(unsigned=True),
+               primary_key=True, autoincrement=True),
+        Column("last_name", VARCHAR(length=255),
+               index=True, unique=True, nullable=False),
+        Column("frequency", FLOAT(), index=False,
+               unique=False, nullable=True, default=None),
+        Column("count", INTEGER(unsigned=True), index=False,
+               unique=False, nullable=True, default=None),
+        Column("status", MEDIUMINT(unsigned=True), index=True, unique=False, nullable=False, default=0,
+               server_default=text("0")),
+        Column("exception", TEXT(), index=False,
+               unique=False, nullable=True, default=None),
+        Column("created_at", TIMESTAMP, nullable=False,
+               server_default=text("CURRENT_TIMESTAMP")),
+        Column("updated_at", TIMESTAMP, nullable=False, index=True, unique=False,
+               server_default=text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")),
+        mysql_collate="utf8mb4_unicode_ci"
+    )
+
+
+def downgrade():
+    op.drop_table("last_names")

--- a/src/python/src/examples/database/versions/create_states_table.py
+++ b/src/python/src/examples/database/versions/create_states_table.py
@@ -1,0 +1,31 @@
+from alembic import op
+from sqlalchemy import Column, text
+from sqlalchemy.dialects.mysql import BIGINT, TIMESTAMP, MEDIUMINT, VARCHAR, TEXT, FLOAT, INTEGER, BOOLEAN
+
+
+revision = None
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "states",
+        Column("id", BIGINT(unsigned=True), primary_key=True, autoincrement=True),
+        Column("name", VARCHAR(length=255), index=True, unique=False, nullable=False),
+        Column("country_id", BIGINT(unsigned=True), index=True, unique=False, nullable=False),
+
+        Column("status", MEDIUMINT(unsigned=True), index=True, unique=False, nullable=False, default=0,
+               server_default=text("0")),
+        Column("exception", TEXT(), index=False, unique=False, nullable=True, default=None),
+        Column("created_at", TIMESTAMP, nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+        Column("updated_at", TIMESTAMP, nullable=False, index=True, unique=False,
+               server_default=text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")),
+        mysql_collate="utf8mb4_unicode_ci"
+    )
+    op.create_unique_constraint('uq_states_first_name_country_id', 'states', ['name', 'country_id'])
+
+
+def downgrade():
+    op.drop_table("states")


### PR DESCRIPTION

Added a directory to store examples: /src/python/src/examples/
Added examples of migrations (/src/python/src/examples/database/versions/):
- create_cities_table;
- create_states_table;
- create_countries_table;
- create_first_names_table;
- create_last_names_table;

Added example models (/src/python/src/examples/database/models/):
- cities.py;
- countries.py;
- first_names.py;
- last_names.py;
- states.py;